### PR TITLE
fix(prerequisites chart): use .Release.Name for kafka cp-schema regis…

### DIFF
--- a/charts/prerequisites/values.yaml
+++ b/charts/prerequisites/values.yaml
@@ -67,7 +67,7 @@ cp-helm-charts:
   cp-schema-registry:
     enabled: true
     kafka:
-      bootstrapServers: "prerequisites-kafka:9092"  # <<release-name>>-kafka:9092
+      bootstrapServers: {{ .Release.Name }}-kafka:9092
   cp-kafka:
     enabled: false
   cp-zookeeper:


### PR DESCRIPTION
Description::
The problem is that currently bootstrapServers list names are not dependent on the release name, while kafka server pod names are dependent on the release name.
This creates an error and a mismatch of names, when the chart is not installed with the default prerequisites name

Solution
Use {{ .Release.Name }} helm variable for kafka cp-schema registry bootstrap server name